### PR TITLE
changed letter cases of employee and admin for heroku in index

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -1,6 +1,6 @@
 //import all models
-const Employee = require('./Employee');
-const Admin = require('./Admin');
+const Employee = require('./employee');
+const Admin = require('./admin');
 
 //create associations
 Admin.hasMany(Employee, {


### PR DESCRIPTION
In the process of deploying to Heroku there was an error with loading the seeds to the database. What was found was a capital letter in the index.js files for Employee and Admin when seeding them. Heroku is very picky and was throwing an error for these two lines of code. The index.js file in seeds was updated to change them each to lowercase and now EMS runs fine.